### PR TITLE
:sparkles: 스프링 빈과 의존관계

### DIFF
--- a/hello-spring/src/main/java/hello/hellospring/controller/MemberController.java
+++ b/hello-spring/src/main/java/hello/hellospring/controller/MemberController.java
@@ -1,0 +1,16 @@
+package hello.hellospring.controller;
+
+import hello.hellospring.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class MemberController {
+    private final MemberService memberService;
+
+    // 스프링 컨테이너에서 memberService를 가져옴.
+    @Autowired
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+}

--- a/hello-spring/src/main/java/hello/hellospring/repository/MemberRepository.java
+++ b/hello-spring/src/main/java/hello/hellospring/repository/MemberRepository.java
@@ -1,10 +1,12 @@
 package hello.hellospring.repository;
 
 import hello.hellospring.domain.Member;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface MemberRepository {
     Member save(Member member);
     Optional<Member> findById(Long id);

--- a/hello-spring/src/main/java/hello/hellospring/service/MemberService.java
+++ b/hello-spring/src/main/java/hello/hellospring/service/MemberService.java
@@ -2,13 +2,19 @@ package hello.hellospring.service;
 
 import hello.hellospring.domain.Member;
 import hello.hellospring.repository.MemberRepository;
-import hello.hellospring.repository.MemoryMemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+@Service
 public class MemberService {
-    private final MemberRepository memberRepository = new
-            MemoryMemberRepository();
+    private final MemberRepository memberRepository ;
+
+    @Autowired
+    public MemberService(MemberRepository memberRepository){
+        this.memberRepository = memberRepository;
+    }
     /**
      * 회원가입
      */


### PR DESCRIPTION
### 어노테이션
@Service @Repository @Controller @Configuration 과 같이 클래스 앞에 어노테이션을 붙여주면 해당 컴포넌트가 어노테이션에 맞는 스프링 빈으로 자동 등록된다.

1. @Service
특별한 처리는 하지 않으나, 개발자들이 핵심 비즈니스 계층을 인식하는데 도움을 준다.

3. @Repository
스프링 데이터 접근 계층으로 인식하고 해당 계층에서 발생하는 예외는 모두 DataAccessException으로 변환한다.
4. @Controller 
스프링 MVC 컨트롤러로 인식된다.

5. @Configuration
특별한 처리는 하지 않으나, 개발자들이 핵심 비즈니스 계층을 인식하는데 도움을 준다.

이 때, 생성자에 @Autowired를 사용하면 객체 생성 시점에 스프링 컨테이너에서 해당 스프링 빈을 찾아서 주입한다. 생성자가 1개만 있으면 @Autowired는 생략할 수 있다.

### 스프링 빈이란? 
Spring Bean이란 스프링 컨테이너에 의해 관리되는 자바 객체를 의미한다.
스프링 컨테이너는 스프링 빈의 생명 주기를 관리하며 생성된 스프링 빈들에게 추가적인 기능을 제공하는 역할을 한다.
